### PR TITLE
Ajustes para funcionar com o Python 3

### DIFF
--- a/lolwikibot.py
+++ b/lolwikibot.py
@@ -1,53 +1,56 @@
-# coding: latin-1
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 import wikia
 import telebot
-from telebot import types
-import requests
 
 TOKEN = "YOUR TOKEN HERE"
-wiki = "leagueoflegends"
-bot = telebot.TeleBot(TOKEN)
+WIKI = "leagueoflegends"
+BOT = telebot.TeleBot(TOKEN)
 
-teclado = types.ReplyKeyboardMarkup(resize_keyboard=True)
-teclado.row('start')
-teclado.row('help')
-teclado.row('info')
+TECLADO = telebot.types.ReplyKeyboardMarkup(resize_keyboard=True)
+TECLADO.row('start')
+TECLADO.row('help')
+TECLADO.row('info')
 
-@bot.message_handler(commands=['start'])
-def send_welcome(message,reply_markup=teclado):
-	bot.reply_to(message, "Este bot faz buscas inline na Wiki de League of Legends, feito por @Arquimago")
-	
-@bot.message_handler(commands=['help'])
-def send_welcome(message,reply_markup=teclado):
-	bot.reply_to(message, "Para utilizar esse bot apenas escreva @lolwbot e os termos da busca, não envie a mensagem apenas aguarde os resultados numa caixa popup")
-	
-@bot.message_handler(commands=['info'])
-def send_welcome(message,reply_markup=teclado):
-	bot.reply_to(message, "O propósito deste bot é apenas fazer buscas inline, se deseja mais interações e informações sobre o jogo, campeões, invocadores, partidas e tudo mais recomendo utilizar o @League_of_Legends_bot criado pelo @Edurolp e com tradução para Português feita por mim (@Arquimago).")
+@BOT.message_handler(commands=['start'])
+def send_welcome_start(message, reply_markup=TECLADO):
+    BOT.reply_to(message, "Testanto o PYTHON 3")
 
-@bot.inline_handler(lambda query: query.query)
+@BOT.message_handler(commands=['help'])
+def send_welcome_help(message, reply_markup=TECLADO):
+    BOT.reply_to(message, "Para utilizar esse bot apenas escreva " \
+        "@lolwbot e os termos da busca, não envie a mensagem apenas " \
+        "aguarde os resultados numa caixa popup")
+
+@BOT.message_handler(commands=['info'])
+def send_welcome_info(message, reply_markup=TECLADO):
+    BOT.reply_to(message, "O propósito deste bot é apenas fazer buscas inline, "\
+        "se deseja mais interações e informações sobre o jogo, campeões, " \
+        "invocadores, partidas e tudo mais recomendo utilizar o " \
+        "@League_of_Legends_bot criado pelo @Edurolp e com tradução para " \
+        "Português feita por mim (@Arquimago).")
+
+@BOT.inline_handler(lambda query: query.query)
 def query_text(inline_query):
-	total = 10
-	try:
-		s = wikia.search(wiki,inline_query.query,total)
-		results = range(0,total)
-		
-		for i in range(0,len(s)):
-			try: 
-				url = wikia.page(wiki,s[i]).url
-			except:
-				break
-			url = url.replace(' ', '%20')
-			title = wikia.page(wiki,s[i]).title
-			id = "%d"%i
-			results[i] = types.InlineQueryResultArticle(id, title, url)
-		
-		bot.answer_inline_query(inline_query.id, results)
-		
-	except Exception as e:
-		print(e)
+    total = 10
+    try:
+        search_results = wikia.search(WIKI, inline_query.query, total)
+        results = []
 
-requests.packages.urllib3.disable_warnings()
+        for i, page_result in enumerate(search_results):
+            try:
+                page = wikia.page(WIKI, page_result)
+            except:
+                break
 
-bot.polling(none_stop=True, interval=0, timeout=20)
+            title, url = page.title, page.url
+            url = url.replace(' ', '%20')
+            results.append(telebot.types.InlineQueryResultArticle(str(i), title, url))
+
+        BOT.answer_inline_query(inline_query.id, results)
+
+    except Exception as ex:
+        print(ex)
+
+BOT.polling(none_stop=True, interval=0, timeout=20)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
-MarkupSafe==0.23
-py==1.4.31
-pyTelegramBotAPI==1.4.1
-pytest==2.8.5
-requests==2.5.3
-six==1.10.0
-wheel==0.26.0
+pyTelegramBotAPI==1.4.2
+wikia==1.4.3


### PR DESCRIPTION
- Ajustei algumas coisas de convenção de código Python, como nome de constantes, tamanho das linhas, etc.
- Modifiquei o for do query_text para funcionar com apenas uma chamada ao wikia.page e substitui o `range` pelo `enumerate`, pois elimina indexar a lista de resultados no for.
- Removi o requests, pois no Python3 estava reclamando que não existia o pacote `packages` (e não deu nenhum warning também). 
